### PR TITLE
chore: update genai-toolbox repo deps name

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,7 +21,7 @@
       pinDigests: true,
     },
     {
-      matchPackageNames: ['googleapis/genai-toolbox'],
+      matchPackageNames: ['googleapis/mcp-toolbox'],
       'semanticCommitType': 'feat'
     }
   ],
@@ -31,7 +31,7 @@
       managerFilePatterns: ["/toolbox_version\\.txt$/"],
       matchStrings: ["(?<currentValue>[\\d\\.]+)"],
       datasourceTemplate: "github-releases",
-      packageNameTemplate: "googleapis/genai-toolbox",
+      packageNameTemplate: "googleapis/mcp-toolbox",
       extractVersionTemplate: "^v(?<version>.*)$",
     }
   ]

--- a/.github/workflows/mirror-changelog.yml
+++ b/.github/workflows/mirror-changelog.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   add-release-notes:
-    if: github.actor == 'renovate-bot' && startsWith(github.head_ref, 'renovate/googleapis-genai-toolbox')
+    if: github.actor == 'renovate-bot' && startsWith(github.head_ref, 'renovate/googleapis-mcp-toolbox')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -38,7 +38,7 @@ jobs:
             const prBody = context.payload.pull_request.body || '';
 
             // Extract the relevant changelog section
-            const startMarker = '<summary>googleapis/genai-toolbox';
+            const startMarker = '<summary>googleapis/mcp-toolbox';
             const endMarker = '</details>';
             const startIndex = prBody.indexOf(startMarker);
             const endIndex = prBody.indexOf(endMarker, startIndex);
@@ -98,8 +98,8 @@ jobs:
                 // To prevent this, we insert an invisible Unicode zero-width space (`\u200B`)
                 // between the '#' and the number in the link text. This breaks the parser's
                 // pattern matching without changing the visual appearance of the link.
-                // E.g., "[#1770](...)" becomes "[genai-toolbox#​1770](...)"
-                originalContent = originalContent.replace(/\[#(\d+)\](\([^)]+\))/g, '[genai-toolbox#\u200B$1]$2');
+                // E.g., "[#1770](...)" becomes "[mcp-toolbox#​1770](...)"
+                originalContent = originalContent.replace(/\[#(\d+)\](\([^)]+\))/g, '[mcp-toolbox#\u200B$1]$2');
                 
                 const lineAsLowerCase = originalContent.toLowerCase();
 

--- a/.github/workflows/package-and-upload-assets.yml
+++ b/.github/workflows/package-and-upload-assets.yml
@@ -18,7 +18,7 @@ name: Package and Upload Release Assets
 env:
   PACKAGE_NAME: "mysql"
   FILES_TO_PACKAGE: "gemini-extension.json MYSQL.md LICENSE"
-  GCS_BUCKET_URL: "https://storage.googleapis.com/genai-toolbox/geminicli"
+  GCS_BUCKET_URL: "https://storage.googleapis.com/mcp-toolbox-for-databases/geminicli"
 
 on:
   release:

--- a/.github/workflows/presubmit-tests.yml
+++ b/.github/workflows/presubmit-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install toolbox binary
         run: |
           VERSION=$(cat toolbox_version.txt)
-          curl -L -o toolbox "https://storage.googleapis.com/genai-toolbox/v${VERSION}/linux/amd64/toolbox"
+          curl -L -o toolbox "https://storage.googleapis.com/mcp-toolbox-for-databases/v${VERSION}/linux/amd64/toolbox"
           chmod +x toolbox
 
       - name: Install Extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,35 +12,35 @@
 
 ### Features
 
-* **tools/mysql-get-query-plan:** Add new `mysql-get-query-plan` tool for MySQL source ([genai-toolbox#​2123](https://redirect.github.com/googleapis/genai-toolbox/issues/2123)) ([0641da0](https://redirect.github.com/googleapis/genai-toolbox/commit/0641da0353857317113b2169e547ca69603ddfde)) ([3506ace](https://github.com/gemini-cli-extensions/mysql/commit/3506ace6e0befd06869da068573fd81b77bec40e))
+* **tools/mysql-get-query-plan:** Add new `mysql-get-query-plan` tool for MySQL source ([mcp-toolbox#​2123](https://redirect.github.com/googleapis/mcp-toolbox/issues/2123)) ([0641da0](https://redirect.github.com/googleapis/mcp-toolbox/commit/0641da0353857317113b2169e547ca69603ddfde)) ([3506ace](https://github.com/gemini-cli-extensions/mysql/commit/3506ace6e0befd06869da068573fd81b77bec40e))
 * add Configuration settings ([#69](https://github.com/gemini-cli-extensions/mysql/issues/69)) ([fee5c1c](https://github.com/gemini-cli-extensions/mysql/commit/fee5c1c546c5547f6db099fd4178b79b01db0950))
 
 
 ### Bug Fixes
 
-* **tools:** Check for query execution error for pgxpool.Pool ([genai-toolbox#​1969](https://redirect.github.com/googleapis/genai-toolbox/issues/1969)) ([2bff138](https://redirect.github.com/googleapis/genai-toolbox/commit/2bff1384a3570ef46bc03ebebc507923af261987)) ([3506ace](https://github.com/gemini-cli-extensions/mysql/commit/3506ace6e0befd06869da068573fd81b77bec40e))
+* **tools:** Check for query execution error for pgxpool.Pool ([mcp-toolbox#​1969](https://redirect.github.com/googleapis/mcp-toolbox/issues/1969)) ([2bff138](https://redirect.github.com/googleapis/mcp-toolbox/commit/2bff1384a3570ef46bc03ebebc507923af261987)) ([3506ace](https://github.com/gemini-cli-extensions/mysql/commit/3506ace6e0befd06869da068573fd81b77bec40e))
 
 ## [0.1.3](https://github.com/gemini-cli-extensions/mysql/compare/0.1.2...0.1.3) (2025-11-18)
 
 
 ### Features
 
-* **source/mysql:** Set default host and port for MySQL source ([genai-toolbox#​1922](https://redirect.github.com/googleapis/genai-toolbox/issues/1922)) ([2c228ef](https://redirect.github.com/googleapis/genai-toolbox/commit/2c228ef4f2d4cb8dfc41e845466bfe3566d141a1)) ([a0d7947](https://github.com/gemini-cli-extensions/mysql/commit/a0d7947a9b5071ee477a01f116abae3b7818f372))
+* **source/mysql:** Set default host and port for MySQL source ([mcp-toolbox#​1922](https://redirect.github.com/googleapis/mcp-toolbox/issues/1922)) ([2c228ef](https://redirect.github.com/googleapis/mcp-toolbox/commit/2c228ef4f2d4cb8dfc41e845466bfe3566d141a1)) ([a0d7947](https://github.com/gemini-cli-extensions/mysql/commit/a0d7947a9b5071ee477a01f116abae3b7818f372))
 
 ## [0.1.2](https://github.com/gemini-cli-extensions/mysql/compare/0.1.1...0.1.2) (2025-10-27)
 
 
 ### Features
 
-* **sources/alloydb,cloudsqlpg,cloudsqlmysql,cloudsqlmssql:** Support PSC connection ([#1686](https://redirect.github.com/googleapis/genai-toolbox/issues/1686)) ([9d2bf79](https://redirect.github.com/googleapis/genai-toolbox/commit/9d2bf79becfda104ef77f34b8d4b22cbedbc4bf3)) ([6349c2c](https://github.com/gemini-cli-extensions/mysql/commit/6349c2c289cef74ad4568419ea24892689c478e0))
-* Add program name to MySQL connections ([#1617](https://redirect.github.com/googleapis/genai-toolbox/issues/1617)) ([c4a22b8](https://redirect.github.com/googleapis/genai-toolbox/commit/c4a22b8d3bd0307325215ebd2f30ba37927cd37e)) ([6349c2c](https://github.com/gemini-cli-extensions/mysql/commit/6349c2c289cef74ad4568419ea24892689c478e0))
+* **sources/alloydb,cloudsqlpg,cloudsqlmysql,cloudsqlmssql:** Support PSC connection ([#1686](https://redirect.github.com/googleapis/mcp-toolbox/issues/1686)) ([9d2bf79](https://redirect.github.com/googleapis/mcp-toolbox/commit/9d2bf79becfda104ef77f34b8d4b22cbedbc4bf3)) ([6349c2c](https://github.com/gemini-cli-extensions/mysql/commit/6349c2c289cef74ad4568419ea24892689c478e0))
+* Add program name to MySQL connections ([#1617](https://redirect.github.com/googleapis/mcp-toolbox/issues/1617)) ([c4a22b8](https://redirect.github.com/googleapis/mcp-toolbox/commit/c4a22b8d3bd0307325215ebd2f30ba37927cd37e)) ([6349c2c](https://github.com/gemini-cli-extensions/mysql/commit/6349c2c289cef74ad4568419ea24892689c478e0))
 
 
 ### Bug Fixes
 
-* **sources/mysql:** Escape mysql user agent ([#1707](https://redirect.github.com/googleapis/genai-toolbox/issues/1707)) ([eeb694c](https://redirect.github.com/googleapis/genai-toolbox/commit/eeb694c20facc40a38bfa67073c4cb1f3dd657ff)) ([6349c2c](https://github.com/gemini-cli-extensions/mysql/commit/6349c2c289cef74ad4568419ea24892689c478e0))
-* **sources/mysql:** Escape program\_name for MySQL ([#1717](https://redirect.github.com/googleapis/genai-toolbox/issues/1717)) ([02f7f8a](https://redirect.github.com/googleapis/genai-toolbox/commit/02f7f8af979057efe99fd138cb1b958130355b68)) ([6349c2c](https://github.com/gemini-cli-extensions/mysql/commit/6349c2c289cef74ad4568419ea24892689c478e0))
-* **tools/mysql-list-tables:** Update sql query to resolve subquery scope error ([#1629](https://redirect.github.com/googleapis/genai-toolbox/issues/1629)) ([94e19d8](https://redirect.github.com/googleapis/genai-toolbox/commit/94e19d87e54e831b80eb766572e48bc7370305d8)) ([6349c2c](https://github.com/gemini-cli-extensions/mysql/commit/6349c2c289cef74ad4568419ea24892689c478e0))
+* **sources/mysql:** Escape mysql user agent ([#1707](https://redirect.github.com/googleapis/mcp-toolbox/issues/1707)) ([eeb694c](https://redirect.github.com/googleapis/mcp-toolbox/commit/eeb694c20facc40a38bfa67073c4cb1f3dd657ff)) ([6349c2c](https://github.com/gemini-cli-extensions/mysql/commit/6349c2c289cef74ad4568419ea24892689c478e0))
+* **sources/mysql:** Escape program\_name for MySQL ([#1717](https://redirect.github.com/googleapis/mcp-toolbox/issues/1717)) ([02f7f8a](https://redirect.github.com/googleapis/mcp-toolbox/commit/02f7f8af979057efe99fd138cb1b958130355b68)) ([6349c2c](https://github.com/gemini-cli-extensions/mysql/commit/6349c2c289cef74ad4568419ea24892689c478e0))
+* **tools/mysql-list-tables:** Update sql query to resolve subquery scope error ([#1629](https://redirect.github.com/googleapis/mcp-toolbox/issues/1629)) ([94e19d8](https://redirect.github.com/googleapis/mcp-toolbox/commit/94e19d87e54e831b80eb766572e48bc7370305d8)) ([6349c2c](https://github.com/gemini-cli-extensions/mysql/commit/6349c2c289cef74ad4568419ea24892689c478e0))
 
 ## [0.1.1](https://github.com/gemini-cli-extensions/mysql/compare/0.1.0...0.1.1) (2025-09-30)
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -33,7 +33,7 @@ The core logic for this extension is handled by a pre-built `toolbox` binary. Th
     VERSION=$(cat toolbox_version.txt)
 
     # Example for macOS/amd64
-    curl -L -o toolbox https://storage.googleapis.com/genai-toolbox/geminicli/v$VERSION/darwin/amd64/toolbox
+    curl -L -o toolbox https://storage.googleapis.com/mcp-toolbox-for-databases/geminicli/v$VERSION/darwin/amd64/toolbox
     chmod +x toolbox
     ```
     Adjust the URL for your operating system (`linux/amd64`, `darwin/arm64`, `windows/amd64`).

--- a/README.md
+++ b/README.md
@@ -119,4 +119,4 @@ Common issues:
 
 * "✖ Error during discovery for server: MCP error -32000: Connection closed": The database connection has not been established. Ensure your configuration is set via environment variables.
 * "✖ MCP ERROR: Error: spawn /Users/USER/.gemini/extensions/mysql/toolbox ENOENT": The Toolbox binary did not download correctly. Ensure you are using Gemini CLI v0.6.0+.
-* "cannot execute binary file": The Toolbox binary did not download correctly. Ensure the correct binary for your OS/Architecture has been downloaded. See [Installing the server](https://googleapis.github.io/genai-toolbox/getting-started/introduction/#installing-the-server) for more information.
+* "cannot execute binary file": The Toolbox binary did not download correctly. Ensure the correct binary for your OS/Architecture has been downloaded. See [Installing the server](https://googleapis.github.io/mcp-toolbox/getting-started/introduction/#installing-the-server) for more information.

--- a/README.md
+++ b/README.md
@@ -119,4 +119,4 @@ Common issues:
 
 * "✖ Error during discovery for server: MCP error -32000: Connection closed": The database connection has not been established. Ensure your configuration is set via environment variables.
 * "✖ MCP ERROR: Error: spawn /Users/USER/.gemini/extensions/mysql/toolbox ENOENT": The Toolbox binary did not download correctly. Ensure you are using Gemini CLI v0.6.0+.
-* "cannot execute binary file": The Toolbox binary did not download correctly. Ensure the correct binary for your OS/Architecture has been downloaded. See [Installing the server](https://googleapis.github.io/mcp-toolbox/getting-started/introduction/#installing-the-server) for more information.
+* "cannot execute binary file": The Toolbox binary did not download correctly. Ensure the correct binary for your OS/Architecture has been downloaded. See [Installing the server](https://mcp-toolbox.dev/documentation/introduction/#install-toolbox) for more information.


### PR DESCRIPTION
Note: link checker will fail until the `genai-toolbox` repository rename is complete.